### PR TITLE
Hinweis auf root-Zufallspasswort im Systemlog ergänzt.

### DIFF
--- a/01-installation/04-postinstallation.md
+++ b/01-installation/04-postinstallation.md
@@ -33,6 +33,7 @@ Außerdem "MySQL aaS", also kein Zugang zu den Kisten für Kunden.
 "Dein RPM macht das schon"
 
 - Root Account gesichert?
+    - Beim Erst-Start aus RPM heraus wird ein Zufallspasswort für root generiert und ins Systemlog geschrieben !!!
 - Permissions im Datadir okay?
 - Keine weiteren Accounts da (früher ""@localhost)
 - Restartable? Service?


### PR DESCRIPTION
Ist imho in 8.0 neu hinzugekommen und besonders riskant, wenn man die Logs zentralisiert...